### PR TITLE
docs: document MIT licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,4 +256,9 @@ Use **semantic colour tokens** instead of hard-coding hex in components.
 ---
 
 ## License
-TBD (e.g., MIT). Add `LICENSE` at the repo root.
+The Pace Tracer is released under the [MIT License](LICENSE).
+
+You may use, copy, modify, merge, publish, distribute, sublicense, and sell
+copies of the software, provided that the copyright notice and permission
+notice from the LICENSE are included in all copies or substantial portions of
+the software.


### PR DESCRIPTION
## Summary
- update the README license section to state the project uses the MIT License
- note the requirement to retain the copyright and permission notices when redistributing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db4dca581483218086eea6a2041331