### PR TITLE
Add role documentation for core engineering disciplines

### DIFF
--- a/docs/roles/devops-platform-engineer.md
+++ b/docs/roles/devops-platform-engineer.md
@@ -1,0 +1,24 @@
+# DevOps & Platform Engineer
+
+## Mission
+Provide resilient infrastructure, deployment automation, and runtime observability so The Pace Tracer ships predictably and recovers quickly across environments.
+
+## Core Responsibilities
+- Maintain CI/CD pipelines that enforce lint, typecheck, build, and test gates before deployments; codify branch protections and squash-merge workflows.
+- Manage environment provisioning and configuration, keeping `.env.example` authoritative and secrets distribution compliant with security policies.
+- Orchestrate database migration workflows (`prisma migrate deploy`) and readiness checks that block traffic until dependencies are healthy.
+- Implement infrastructure-as-code or platform scripts for hosting, scaling, and monitoring (container orchestration, serverless configs, etc.).
+- Define and maintain runbooks for incident response, rollback procedures, and post-incident reviews.
+
+## Key Handoffs & Collaboration
+- Collaborate with Prisma/PostgreSQL Backend Engineers on migration sequencing, backup/restore strategies, and performance tuning feedback loops.
+- Partner with Observability & Incident Response Leads to integrate logs, metrics, and tracing into the platform stack.
+- Support Next.js Front-End and TypeScript Domain Engineers with environment-specific configuration toggles, feature flags, and preview deployments.
+- Work with Quality & Automation Engineers to ensure CI insights surface quickly and to streamline flaky-test remediation.
+
+## Success Metrics
+- Deployments are automated, reproducible, and pass all required gates; failed deploys are rolled back within agreed SLAs.
+- Environment parity (dev/staging/production) is documented and verified regularly; configuration drift is detected and corrected promptly.
+- Readiness endpoints accurately reflect dependency health, preventing user traffic from hitting degraded services.
+- Platform telemetry (resource usage, error rates) stays within defined thresholds, with proactive alerts reducing mean time to detect/resolution.
+- Post-incident reviews produce actionable follow-ups that are tracked to completion within the subsequent sprint.

--- a/docs/roles/documentation-knowledge-steward.md
+++ b/docs/roles/documentation-knowledge-steward.md
@@ -1,0 +1,24 @@
+# Documentation & Knowledge Steward
+
+## Mission
+Keep The Pace Tracer's institutional knowledge accurate, accessible, and actionable by curating documentation, decision records, and learning resources across the organisation.
+
+## Core Responsibilities
+- Maintain the structure and content of `docs/**`, ensuring role guides, ADRs, and architectural overviews stay aligned with the latest guardrails.
+- Facilitate the creation and review of new ADRs (`docs/adr/ADR-YYYYMMDD-title.md`) when cross-cutting decisions arise.
+- Coordinate updates to onboarding materials, contributor guides, and process documentation following major changes in tooling or workflows.
+- Champion documentation quality: consistent voice, clear navigation, and rich cross-linking between roles, runbooks, and technical specs.
+- Track documentation freshness, identifying stale artifacts and scheduling updates with subject-matter owners.
+
+## Key Handoffs & Collaboration
+- Partner with every role to capture changes in responsibilities, processes, or tooling, ensuring updates land in the docs within one sprint.
+- Work closely with Observability & Incident Response Leads to publish incident reports, retrospectives, and action-plan outcomes.
+- Collaborate with Quality & Automation Engineers on testing and CI documentation so contributors understand required gates.
+- Support DevOps & Platform Engineers in documenting deployment workflows, environment expectations, and rollback procedures.
+
+## Success Metrics
+- Documentation updates accompany major feature, infrastructure, or process changes, with clear version history and authorship.
+- Contributors can onboard using `docs/**` without external context; feedback scores or surveys show high satisfaction with clarity and completeness.
+- ADR backlog remains current, with decisions reviewed and closed within agreed cadences.
+- Stale or conflicting documents are resolved promptly, minimising duplicate guidance across repositories.
+- Role guides, including this document, remain synchronized with AGENTS.md guardrails whenever they evolve.

--- a/docs/roles/nextjs-front-end-engineer.md
+++ b/docs/roles/nextjs-front-end-engineer.md
@@ -1,0 +1,24 @@
+# Next.js Front-End Engineer
+
+## Mission
+Own the App Router user interface for The Pace Tracer, delivering resilient and accessible experiences while enforcing layered architecture contracts (UI → core/app), design token usage, and documented error boundaries.
+
+## Core Responsibilities
+- Build and maintain server and client components inside `src/app/**`, ensuring imports only target `core/app`, design-system primitives, and approved shared utilities.
+- Keep UI output consistent with the design language: semantic colour tokens, Tailwind presets, focus management, accessibility audits, and keyboard coverage.
+- Implement and maintain route-level error boundaries (`error.tsx`, `global-error.tsx`, `not-found.tsx`) with structured logging hooks and user-facing recovery paths.
+- Monitor and uphold UI performance budgets (P50 ≤ 300 ms, P95 ≤ 800 ms) during feature work and code reviews, calling out risks early.
+- Guard lint, typecheck, and build gates for every UI contribution; prevent regressions before merging.
+
+## Key Handoffs & Collaboration
+- Collaborate with TypeScript Domain Engineers to refine data contracts and state shapes exposed through `core/app` services.
+- Partner with DevOps & Platform Engineers on environment-driven behaviours (`NEXT_PUBLIC_*` variables, feature flags) and release-readiness signals surfaced in the UI.
+- Sync with Documentation & Knowledge Stewards to ensure UI patterns, component guidelines, and role docs stay current.
+- Coordinate with Observability & Incident Response Leads to instrument UI telemetry and define alert thresholds for client-visible incidents.
+
+## Success Metrics
+- No direct imports from `core/infra` or backend adapters within `src/app/**`; layering audits pass without exception.
+- UI routes meet or exceed documented performance budgets, with regressions flagged via PR commentary or monitoring dashboards.
+- Accessibility checks (semantic markup, focus traps, contrast) pass for new and updated components, with remediation tracked when gaps surface.
+- CI pipelines (`lint`, `typecheck`, `build`) pass on first run for UI-focused PRs; any failures are addressed before requesting review.
+- Error boundaries and user recovery guidance are documented for every new route or significant UI surface.

--- a/docs/roles/observability-incident-response-lead.md
+++ b/docs/roles/observability-incident-response-lead.md
@@ -1,0 +1,25 @@
+# Observability & Incident Response Lead
+
+## Mission
+Ensure The Pace Tracer remains transparent and recoverable by defining telemetry standards, incident playbooks, and alerting thresholds that keep teams informed and responsive.
+
+## Core Responsibilities
+- Establish structured logging, metrics, and tracing conventions across UI, domain, and infrastructure components, emphasising correlation IDs and PII safeguards.
+- Configure dashboards and alerting rules that surface performance budget breaches, error spikes, and dependency failures in real time.
+- Maintain incident response workflows: severity definitions, on-call rotations, escalation paths, and communication templates.
+- Lead post-incident reviews, capturing root causes, corrective actions, and documentation updates.
+- Integrate observability feedback into development practices, influencing error boundary design, retry logic, and resilience improvements.
+
+## Key Handoffs & Collaboration
+- Partner with DevOps & Platform Engineers to wire telemetry collectors, log pipelines, and monitoring infrastructure.
+- Collaborate with Next.js Front-End Engineers on user-facing error handling, ensuring observability hooks exist for key UI flows.
+- Work with Prisma/PostgreSQL Backend Engineers to track database health signals, slow queries, and migration anomalies.
+- Coordinate with Quality & Automation Engineers to incorporate production learnings into automated regression suites.
+- Sync with Documentation & Knowledge Stewards to publish incident reports, runbooks, and observability standards.
+
+## Success Metrics
+- Critical services expose complete telemetry (logs, metrics, traces) with correlation coverage exceeding 95% of requests.
+- Alerting achieves high signal-to-noise ratios: false positives trend downward, and true incidents trigger within defined detection SLAs.
+- Post-incident action items are assigned and resolved within committed timelines, reducing repeat occurrences.
+- Observability standards are reflected in code reviews and documentation updates, with tooling adoption tracked across teams.
+- Stakeholders report improved visibility into system health during quarterly reviews or readiness assessments.

--- a/docs/roles/prisma-postgresql-backend-engineer.md
+++ b/docs/roles/prisma-postgresql-backend-engineer.md
@@ -1,0 +1,24 @@
+# Prisma/PostgreSQL Backend Engineer
+
+## Mission
+Design and maintain the data persistence layer that powers The Pace Tracer, ensuring Prisma models and PostgreSQL migrations remain the authoritative, reproducible source of truth across environments.
+
+## Core Responsibilities
+- Model database schemas within `prisma/schema.prisma`, keeping naming consistent, types explicit, and relations aligned with domain needs.
+- Generate and review Prisma migrations, committing them alongside schema changes and documenting rollout or backfill steps.
+- Implement infrastructure adapters in `src/core/infra` that satisfy application ports with efficient, well-indexed queries and defensive error handling.
+- Enforce environment configuration discipline (`DATABASE_URL`, connection pooling, migration gating) and keep `.env.example` current.
+- Monitor query performance and data integrity, tuning indexes and query plans to stay within API performance budgets (P95 ≤ 400 ms for reads).
+
+## Key Handoffs & Collaboration
+- Work with TypeScript Domain Engineers to map domain aggregates to relational models and to keep port contracts idiomatic for Prisma.
+- Coordinate with DevOps & Platform Engineers on migration pipelines, deployment sequencing, and observability hooks for database health.
+- Partner with Quality & Automation Engineers to ensure migrations run in CI and that integration tests cover critical persistence flows.
+- Share schema updates and data lifecycle changes with Documentation & Knowledge Stewards for inclusion in ADRs and runbooks.
+
+## Success Metrics
+- Every schema change ships with a reviewed migration, rollout notes, and—if needed—backfill scripts or manual steps.
+- Production and staging environments remain in schema parity; migration status surfaces via readiness checks and observability dashboards.
+- Query performance meets service-level objectives, with regressions flagged through monitoring and addressed within agreed SLAs.
+- Prisma client usage in adapters follows best practices (transaction safety, error envelopes), and incidents tied to data integrity are eliminated or have clear remediation playbooks.
+- Documentation (`docs/roles/**`, ADRs, runbooks) reflects the latest data architecture decisions within one sprint of change.

--- a/docs/roles/quality-automation-engineer.md
+++ b/docs/roles/quality-automation-engineer.md
@@ -1,0 +1,24 @@
+# Quality & Automation Engineer
+
+## Mission
+Safeguard code quality by maintaining reliable automated checks, fast feedback loops, and pragmatic testing strategies that keep The Pace Tracer shippable at all times.
+
+## Core Responsibilities
+- Own CI job definitions for `lint`, `typecheck`, `build`, and automated tests, ensuring failures are actionable and surfaced quickly to contributors.
+- Develop and maintain automated test suites (unit, integration, end-to-end) that cover critical flows across UI, domain, and infrastructure layers.
+- Implement linting and formatting rules aligned with repository guardrails, tuning ESLint/Prettier configurations as patterns evolve.
+- Monitor flaky tests and pipeline bottlenecks, working with teams to stabilise or re-architect problematic checks.
+- Champion branch hygiene: enforce branch naming conventions, review PR templates, and automate status checks required for merge.
+
+## Key Handoffs & Collaboration
+- Partner with Next.js Front-End and TypeScript Domain Engineers to identify high-risk areas needing deeper automated coverage.
+- Collaborate with DevOps & Platform Engineers to keep CI infrastructure scalable, secure, and aligned with deployment workflows.
+- Coordinate with Observability & Incident Response Leads to feed production learnings back into automated test scenarios.
+- Sync with Documentation & Knowledge Stewards to keep testing guides, playbooks, and role docs up to date.
+
+## Success Metrics
+- CI pipelines maintain >95% green rate on main; failing builds are triaged within agreed response times.
+- Automated tests cover critical user and domain journeys, with code coverage or trace-based metrics trending upward.
+- Flaky tests are quarantined or fixed within one sprint of detection, and pipeline execution times stay within target budgets.
+- Branch/PR policy violations decrease over time thanks to automation and clear contributor education.
+- Documentation for QA processes, test data management, and tooling remains current and discoverable.

--- a/docs/roles/typescript-domain-engineer.md
+++ b/docs/roles/typescript-domain-engineer.md
@@ -1,0 +1,24 @@
+# TypeScript Domain Engineer
+
+## Mission
+Maintain a strictly typed, framework-agnostic domain and application service layer under `src/core/**`, ensuring business rules remain portable, testable, and enforce the "imports point up" contract.
+
+## Core Responsibilities
+- Model domain rules, entities, and value objects within `src/core/domain`, avoiding framework or IO dependencies.
+- Implement application services in `src/core/app` that orchestrate domain logic, expose stable contracts to the UI, and consume infrastructure ports.
+- Define and evolve port interfaces for infrastructure adapters, keeping them explicit and well-documented.
+- Uphold strict TypeScript settings (no implicit `any`, `noUnusedLocals`, `exactOptionalPropertyTypes`) and introduce generics/utility types where they improve safety.
+- Author unit tests or property-based checks that validate domain behaviour independent of Next.js or Prisma layers.
+
+## Key Handoffs & Collaboration
+- Partner with Next.js Front-End Engineers to clarify data requirements, ensure DTOs stay minimal, and prevent leaking infrastructure details.
+- Collaborate with Prisma/PostgreSQL Backend Engineers to translate port contracts into concrete adapters and keep schema changes reflected in domain models.
+- Work with Quality & Automation Engineers to maintain fast feedback loops (type checking, unit tests) and to expand coverage as business rules grow.
+- Coordinate with Documentation & Knowledge Stewards to capture domain-specific ADRs and update role documentation when invariants change.
+
+## Success Metrics
+- Domain and application layers compile without unused exports, cyclic imports, or lint violations; layering audits show no downward dependency leaks.
+- Interfaces between `core/app` and `core/infra` stay stable across releases, with changes communicated via PR summaries and documentation updates.
+- Automated tests cover critical domain invariants, catching regressions before they reach integration layers.
+- PRs introducing new rules include clear docstrings or inline comments explaining invariants and failure modes.
+- Domain-related ADRs are drafted for cross-cutting decisions, and role documentation is refreshed promptly when new patterns emerge.


### PR DESCRIPTION
## Summary
- add dedicated role guides under docs/roles for key engineering responsibilities
- outline mission, responsibilities, handoffs, and success metrics tailored to The Pace Tracer stack

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68db7067b14c8321a9271046afde727d