### PR TITLE
Handle Prisma availability for mock repositories

### DIFF
--- a/src/core/infra/prisma/prismaClient.ts
+++ b/src/core/infra/prisma/prismaClient.ts
@@ -1,13 +1,72 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
-const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
 
-export const prisma =
-  globalForPrisma.prisma ??
-  new PrismaClient({
-    log: process.env.PRISMA_LOG_LEVEL === 'query' ? ['query', 'info', 'warn', 'error'] : ['info', 'warn', 'error'],
-  });
+let prismaInstance: PrismaClient | undefined;
 
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
+export class PrismaClientInitializationError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'PrismaClientInitializationError';
+    this.cause = cause;
+  }
 }
+
+const createPrismaClient = (): PrismaClient => {
+  if (!process.env.DATABASE_URL) {
+    throw new PrismaClientInitializationError(
+      'DATABASE_URL is not defined. PrismaClient cannot be initialised.',
+    );
+  }
+
+  if (prismaInstance) {
+    return prismaInstance;
+  }
+
+  const existingClient = globalForPrisma.prisma;
+
+  if (existingClient) {
+    prismaInstance = existingClient;
+    return existingClient;
+  }
+
+  try {
+    const client = new PrismaClient({
+      log:
+        process.env.PRISMA_LOG_LEVEL === 'query'
+          ? ['query', 'info', 'warn', 'error']
+          : ['info', 'warn', 'error'],
+    });
+
+    if (process.env.NODE_ENV !== 'production') {
+      globalForPrisma.prisma = client;
+    }
+
+    prismaInstance = client;
+
+    return client;
+  } catch (error) {
+    throw new PrismaClientInitializationError(
+      'Failed to create PrismaClient instance.',
+      error,
+    );
+  }
+};
+
+export const getPrismaClient = (): PrismaClient => {
+  if (prismaInstance) {
+    return prismaInstance;
+  }
+
+  return createPrismaClient();
+};
+
+export const isPrismaClientInitializationError = (
+  error: unknown,
+): error is PrismaClientInitializationError =>
+  error instanceof PrismaClientInitializationError ||
+  error instanceof Prisma.PrismaClientInitializationError;

--- a/src/core/infra/prisma/prismaLapRepository.ts
+++ b/src/core/infra/prisma/prismaLapRepository.ts
@@ -1,9 +1,11 @@
 import type { Lap } from '@core/domain';
 import type { LapRepository } from '@core/app';
-import { prisma } from './prismaClient';
+import { getPrismaClient } from './prismaClient';
 
 export class PrismaLapRepository implements LapRepository {
   async listByDriver(driverName: string): Promise<Lap[]> {
+    const prisma = getPrismaClient();
+
     const laps = await prisma.lap.findMany({
       where: { driverName },
       orderBy: { lapNumber: 'asc' },

--- a/src/dependencies/server.ts
+++ b/src/dependencies/server.ts
@@ -1,51 +1,58 @@
 import { LapSummaryService } from '@core/app';
-import { PrismaLapRepository } from '@core/infra';
+import {
+  PrismaLapRepository,
+  isPrismaClientInitializationError,
+} from '@core/infra';
+
+type MockLapSeed = {
+  id: string;
+  lapNumber: number;
+  lapTimeMs: number;
+};
+
+const MOCK_LAPS: ReadonlyArray<MockLapSeed> = [
+  { id: 'mock-1', lapNumber: 1, lapTimeMs: 92345 },
+  { id: 'mock-2', lapNumber: 2, lapTimeMs: 91012 },
+];
+
+const FALLBACK_LAPS: ReadonlyArray<MockLapSeed> = [
+  { id: 'fallback-1', lapNumber: 1, lapTimeMs: 95000 },
+];
 
 class MockLapRepository extends PrismaLapRepository {
   override async listByDriver(driverName: string) {
     if (!process.env.DATABASE_URL) {
-      return [
-        {
-          id: 'mock-1',
-          driverName,
-          lapNumber: 1,
-          lapTimeMs: 92345,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-        {
-          id: 'mock-2',
-          driverName,
-          lapNumber: 2,
-          lapTimeMs: 91012,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      ].map((lap) => ({
-        id: lap.id,
-        driverName: lap.driverName,
-        lapNumber: lap.lapNumber,
-        lapTime: { milliseconds: lap.lapTimeMs },
-        createdAt: lap.createdAt,
-        updatedAt: lap.updatedAt,
-      }));
+      return this.buildLapsFromSeed(driverName, MOCK_LAPS);
     }
 
     try {
       return await super.listByDriver(driverName);
     } catch (error) {
-      console.warn('Falling back to mock lap data', error);
-      return [
-        {
-          id: 'fallback-1',
-          driverName,
-          lapNumber: 1,
-          lapTime: { milliseconds: 95000 },
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      ];
+      if (isPrismaClientInitializationError(error)) {
+        console.warn(
+          'Prisma client unavailable. Falling back to mock lap data.',
+          error,
+        );
+        return this.buildLapsFromSeed(driverName, MOCK_LAPS);
+      }
+
+      console.warn('Falling back to mock lap data after unexpected error.', error);
+      return this.buildLapsFromSeed(driverName, FALLBACK_LAPS);
     }
+  }
+
+  private buildLapsFromSeed(
+    driverName: string,
+    seed: ReadonlyArray<MockLapSeed>,
+  ) {
+    return seed.map((lap) => ({
+      id: lap.id,
+      driverName,
+      lapNumber: lap.lapNumber,
+      lapTime: { milliseconds: lap.lapTimeMs },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
   }
 }
 


### PR DESCRIPTION
## Summary
- lazily initialize the Prisma client and surface a specific initialization error helper
- update the Prisma Lap repository to request the client through the lazy getter
- fall back to seeded lap data when Prisma is unavailable in the mocked server dependency

## Testing
- npm run dev *(fails: Next.js cannot resolve the existing `@core/app` alias in this environment)*
- DATABASE_URL=postgresql://user:pass@localhost:5432/db npm run dev *(fails: Next.js cannot resolve the existing `@core/app` alias in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db9f24f0548321bd090f83f4d67f2b