### PR TITLE
Add root-level core path aliases

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
       "@/*": ["src/*"],
       "@core/domain/*": ["src/core/domain/*"],
       "@core/app/*": ["src/core/app/*"],
-      "@core/infra/*": ["src/core/infra/*"]
+      "@core/infra/*": ["src/core/infra/*"],
+      "@core/app": ["src/core/app/index.ts"],
+      "@core/domain": ["src/core/domain/index.ts"],
+      "@core/infra": ["src/core/infra/index.ts"]
     },
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary
- add root-level path aliases for the core app, domain, and infra entry points in the TypeScript configuration to support concise imports

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db9f12be5c8321b70326db404cc20e