### PR TITLE
docs: clarify web vitals reporting

### DIFF
--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,12 +1,17 @@
 import type { NextWebVitalsMetric } from 'next/app';
 
+// Limit the list of metrics we forward so we only capture the signals we
+// actively monitor. CLS, LCP, and INP line up with Google's Core Web Vitals.
 const trackedMetrics = new Set<NextWebVitalsMetric['name']>(['CLS', 'LCP', 'INP']);
 
 export function reportWebVitals(metric: NextWebVitalsMetric) {
+  // Ignore any metrics we do not track to avoid noise in the analytics backend.
   if (!trackedMetrics.has(metric.name)) {
     return;
   }
 
+  // Serialize the payload with the metric information and useful context for
+  // downstream analysis, such as the page path and a timestamp.
   const body = JSON.stringify({
     id: metric.id,
     name: metric.name,
@@ -16,11 +21,15 @@ export function reportWebVitals(metric: NextWebVitalsMetric) {
     timestamp: Date.now(),
   });
 
+  // Prefer navigator.sendBeacon when available to ensure the request is fired
+  // even if the page is unloading (e.g., user navigates away).
   if (navigator.sendBeacon) {
     navigator.sendBeacon('/api/web-vitals', body);
     return;
   }
 
+  // Fallback to fetch for browsers that do not support sendBeacon. The keepalive
+  // flag allows the POST to complete during page unload events.
   fetch('/api/web-vitals', {
     method: 'POST',
     body,


### PR DESCRIPTION
## Summary
- document the intent behind the web vitals reporter implementation
- explain why specific metrics are tracked and how the payload is sent

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68dcbb3a18f88321af287af91d6eaca6