### PR TITLE
docs: define LiveRC ingestion contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,10 @@ Use **semantic colour tokens** instead of hard-coding hex in components.
 ## Docs & ADRs
 - Keep `/.env.example` authoritative and in sync with the Codex Environment.
 - Author **ADRs** under `docs/adr/ADR-YYYYMMDD-title.md` when a choice is **cross-cutting**, **breaking**, **costly to reverse**, or **security/ops-critical** (include context, options, decision, consequences, follow-ups).
+- Keep the LiveRC ingestion contract at [`docs/integrations/liverc-data-model.md`](docs/integrations/liverc-data-model.md) up to date whenever schema or connector rules change.
 - Forthcoming docs (placeholders for now):
-  - `docs/design-principles.md` — layering exceptions, server/client rules, ADR policy  
-  - `docs/ux-principles.md` — layout, spacing, accessibility, token map  
+  - `docs/design-principles.md` — layering exceptions, server/client rules, ADR policy
+  - `docs/ux-principles.md` — layout, spacing, accessibility, token map
   - `docs/domain-model.md` — entities/relations/invariants  
   - `docs/agents/**` — policies, prompts, checklists (auth-ux, auth-security, accessibility, telemetry)  
   - `docs/roles/**` — responsibilities & handoffs

--- a/docs/guardrails/product-guardrails.md
+++ b/docs/guardrails/product-guardrails.md
@@ -24,6 +24,7 @@ Success is measured by the time it takes a driver to understand: *How fast am I?
    - Connector must import by **event**, **session**, or **driver**.
    - Data is stored in a normalised internal format optimised for lap-wise comparisons and deltas.
    - Handle re-imports idempotently (no duplicate laps/sessions).
+   - Follow the shared contract in [`docs/integrations/liverc-data-model.md`](../integrations/liverc-data-model.md) for endpoint coverage, field mapping, and filtering rules.
 3. **Competitor comparisons**
    - Allow selection of any number of competitors from the same event/session so that a comparison can be made between the logged in driver and their competitors.
    - Visualise per-lap times and deltas relative to a chosen baseline (e.g., fastest driver, selected competitor, or self).

--- a/docs/integrations/liverc-data-model.md
+++ b/docs/integrations/liverc-data-model.md
@@ -1,0 +1,174 @@
+# LiveRC → TPTE Data Contract
+
+This note captures the mapping between LiveRC timing endpoints and the Pace Tracer
+Prisma/domain schema. Use it as the contract for every ingestion change so that
+new adapters and tests stay aligned.
+
+## Reference schema
+
+| Layer | Shape |
+| --- | --- |
+| Prisma | `Lap { id: String @id, driverName: String, lapNumber: Int, lapTimeMs: Int, createdAt: DateTime, updatedAt: DateTime, @@unique([driverName, lapNumber]) }` |
+| Domain | `Lap { id: string; driverName: string; lapNumber: number; lapTime: { milliseconds: number }; createdAt: Date; updatedAt: Date; }` |
+
+> **Identifiers**
+> - The canonical lap identifier is `sha256(eventId + sessionId + raceId +
+>   driverId + lapNumber)` stored in Prisma `Lap.id`.
+> - `driverName` is the LiveRC display name normalised to NFC, trimmed, and
+>   collapsed internal whitespace.
+> - `lapNumber` is 1-based as delivered by LiveRC.
+> - `lapTimeMs` is the lap duration converted into milliseconds (rounded to the
+>   nearest whole number).
+
+All ingestion pipelines must convert upstream payloads into the above shapes.
+Timestamps `createdAt` and `updatedAt` are set by Prisma; do not try to mirror
+remote timestamps.
+
+## Endpoint overview
+
+| Endpoint | LiveRC route | Purpose |
+| --- | --- | --- |
+| Entry list | `/results/{eventSlug}/{classSlug}/entry-list.json` | Discover drivers, car numbers, and membership in a class. |
+| Heat sheet | `/results/{eventSlug}/{classSlug}/{roundSlug}/heats.json` | Enumerate heats and race IDs within a round. |
+| Round ranking | `/results/{eventSlug}/{classSlug}/{roundSlug}/ranking.json` | Determine advancing drivers and seeding. |
+| Multi-main | `/results/{eventSlug}/{classSlug}/multi-main.json` | Resolve combined main events (A/B/C) into a single order. |
+| Race result | `/results/{eventSlug}/{classSlug}/{roundSlug}/{raceSlug}.json` | Fetch lap-by-lap timing, penalties, and metadata per race. |
+
+### Entry list
+
+**Purpose:** establish the roster and canonical driver identifiers for a class.
+
+**Key fields and mapping**
+
+| LiveRC field | Example | Mapping |
+| --- | --- | --- |
+| `entry_id` | `"1738295"` | Stable identifier used in hash key. Store as `driverId`. |
+| `display_name` | `"Ryan Maifield"` | Normalised and persisted as `driverName`. |
+| `car_number` | `"5"` | Stored in ingestion metadata only; not part of `Lap`. |
+| `class_id` | `"45932"` | Used to scope downstream requests; stored in ingestion cache. |
+
+**Filtering rules**
+
+- Drop entries without an `entry_id` (cannot dedupe laps).
+- Ignore entries flagged `withdrawn: true`.
+- When URLs point to a driver-specific page, filter the entry list to that
+  driver ID before scheduling race downloads.
+
+### Heat sheet
+
+**Purpose:** map rounds to race (heat/main) identifiers per class.
+
+**Key fields and mapping**
+
+| LiveRC field | Mapping |
+| --- | --- |
+| `heat_id` | Treated as `raceId` component for later hashes. |
+| `round_id` | Combined with class/event to request ranking + race result files. |
+| `session_type` | Used to filter to heats vs mains. `"Qual"` and `"Main"` are kept; `"Practice"` is skipped. |
+| `group_name` | Persisted in ingestion metadata for UI labels. |
+
+**Filtering rules**
+
+- Only schedule heats whose `session_type` matches the session or class slug in
+  the supplied URL (e.g., ignore Truck heats when the URL targets Buggy).
+- When a session URL is supplied, include only heats whose `round_id` equals the
+  targeted round.
+
+### Round ranking
+
+**Purpose:** identify which drivers advance and canonicalise driver ordering.
+
+**Key fields and mapping**
+
+| LiveRC field | Mapping |
+| --- | --- |
+| `entry_id` | Join back to entry list for canonical driver data. |
+| `rank` | Stored in ingestion metadata for seeding; not persisted to Prisma. |
+| `round_points` | Used to determine drop races; influences session selection but not persisted. |
+
+**Filtering rules**
+
+- Discard rankings whose `status` is not `"complete"`.
+- When the ingestion is driver-scoped, keep only rows matching the target
+  `entry_id`.
+
+### Multi-main
+
+**Purpose:** flatten multiple mains for the same class into a composite result.
+
+**Key fields and mapping**
+
+| LiveRC field | Mapping |
+| --- | --- |
+| `main_id` | Appended to `raceId` when hashing lap IDs to disambiguate mains. |
+| `entry_id` | Joins to driver metadata. |
+| `position_overall` | Stored for downstream analytics; not persisted in Prisma. |
+
+**Filtering rules**
+
+- Keep only mains flagged `status: "complete"`.
+- Respect the selected main letter from the URL (e.g., `/amain/` only pulls
+  `main_id` values whose `letter` is `"A"`).
+
+### Race result
+
+**Purpose:** source of lap-by-lap timing that feeds the `Lap` table.
+
+**Key fields and mapping**
+
+| LiveRC field | Example | Mapping |
+| --- | --- | --- |
+| `race_id` | `"793015"` | Combined with other IDs to hash `Lap.id`. |
+| `entry_id` | `"1738295"` | Driver identifier (from entry list). |
+| `driver_name` | `"Ryan Maifield"` | Normalised → `driverName`. |
+| `laps` | Array of lap objects | Each lap transformed to Prisma `Lap`. |
+| `laps[].lap` | `1` | → `lapNumber`. |
+| `laps[].lap_time` | `32.745` seconds | Multiply by `1000` → `lapTimeMs`. |
+| `laps[].is_outlap` | `true`/`false` | Captured in metadata; not persisted yet but used for filtering. |
+| `laps[].penalties` | Array | Used to tag laps in metadata; does not change `lapTimeMs` directly. |
+
+**Transformation sequence**
+
+1. Normalise driver metadata using the entry list join.
+2. Sort laps by `lap` ascending.
+3. Convert `lap_time` seconds → integer milliseconds (`Math.round(seconds * 1000)`).
+4. Generate deterministic `Lap.id` hash from `eventId`, `classId`, `raceId`,
+   `entryId`, and `lapNumber`.
+5. Upsert into Prisma using the `(driverName, lapNumber)` unique constraint to
+   deduplicate re-ingests.
+
+**Filtering rules**
+
+- Skip laps where `lap_time` is `0` or `null` (incomplete timing pass).
+- Exclude laps flagged `is_outlap` when downstream consumers request *race-only*
+  segments; keep them otherwise for auditing.
+- When ingestion is scoped by driver, fetch only the race result blocks for the
+  target `entry_id`.
+
+## Derived metadata
+
+While only lap rows are persisted today, the ingestion pipeline must surface the
+following metadata for higher layers:
+
+- `eventId`, `eventName`, `classId`, `className`, `sessionId`, `sessionType`,
+  `roundId`, `roundName`, `raceId`, `raceName` — required for session selection
+  and UI breadcrumbs.
+- `totalTimeMs`, `fastLapMs`, `averageLapMs`, `penalties[]`, `outlapCount`,
+  `pitCount` — cached in-memory for chart preparation.
+- `source` envelope with timestamp, endpoint URL, HTTP status, and checksum to
+  support audit trails.
+
+All metadata should travel through the app-layer ingestion service but remain
+outside the Prisma schema until we widen storage.
+
+## Contract tests
+
+- Fixture-based contract tests must assert that the same LiveRC payload hashed
+  twice produces identical `Lap.id` values.
+- Race results without a matching entry list row must be rejected (avoid orphan
+  laps).
+- Duplicate laps (same driver + lap number) must update the existing row rather
+  than insert a second copy.
+
+Any future schema changes must update this document, regenerate fixtures, and
+communicate the new rules to downstream teams.

--- a/src/core/app/README.md
+++ b/src/core/app/README.md
@@ -1,0 +1,67 @@
+# `core/app` services
+
+This package coordinates domain logic with infra adapters. The LiveRC ingestion
+service (to be implemented) will follow the pipeline below so all connectors stay
+consistent with the [`LiveRC → TPTE Data Contract`](../../../docs/integrations/liverc-data-model.md).
+
+## Ingestion workflow
+
+1. **Bootstrap context**
+   - Accept one or more LiveRC URLs (event, class, session, or driver views).
+   - Parse the URL to extract `eventSlug`, `classSlug`, optional `roundSlug`,
+     `raceSlug`, and/or `entryId` query parameters.
+   - Resolve the target scope: *event-wide*, *class-only*, *specific round*, or
+     *single driver*.
+
+2. **Discovery (entry list + session selection)**
+   - Fetch the entry list for each targeted class.
+   - Normalise driver names to NFC and cache `entry_id` → driver metadata.
+   - When URLs include a driver filter, drop all other entries before
+     scheduling downstream requests.
+   - Load the heat sheet for each relevant round and filter heats whose
+     `session_type` matches the URL intent (e.g., skip practice when the URL is a
+     qualifying round).
+   - Combine ranking and multi-main data to determine which race IDs are
+     complete and relevant to the selected drivers/classes.
+
+3. **Download + normalise race data**
+   - For each race ID, fetch the race result JSON.
+   - Join back to the cached entry list to enrich driver metadata (number,
+     spelling, sponsor tags) before creating domain models.
+   - Convert lap times to integer milliseconds and generate deterministic lap
+     IDs as described in the data contract.
+   - Tag laps with metadata (`isOutlap`, penalties) to support filtering in the
+     app layer.
+
+4. **Deduplication and persistence**
+   - Upsert every lap through the Prisma `Lap` model using the composite
+     constraint `(driverName, lapNumber)` to guarantee idempotency.
+   - If a new payload reports fewer laps than currently stored for the same
+     driver/race, delete the superseded rows so re-scored results stay accurate.
+   - Persist import metadata (source URL, fetched at, checksum) alongside the lap
+     batch once the infra layer exposes a store for it.
+
+5. **Session/class selection heuristics**
+   - **Event URL** → ingest every class whose slug matches the supplied path.
+     Respect class filters embedded in query parameters (e.g., `?class=2wd-mod`).
+   - **Class URL** → ingest only the matching class; include all completed rounds
+     unless a `round` query parameter is supplied.
+   - **Session URL** → ingest only heats/mains whose round or race slug matches
+     the path segment (e.g., `/round-3/heat-2` → `round_id === 3`, `heat_id === 2`).
+   - **Driver URL** → intersect the above scopes with the targeted `entry_id` to
+     avoid pulling unrelated drivers.
+
+6. **Normalisation outputs**
+   - Return an application DTO describing the import (counts, fastest lap,
+     per-driver summary) alongside the persisted lap IDs.
+   - Emit structured logs and analytics events (success/failure, scope, source
+     URLs) for observability.
+
+## Testing guidance
+
+- Provide fixture payloads for each LiveRC endpoint and assert that repeated
+  ingestion runs are idempotent.
+- Mock infra adapters in unit tests so the domain/service logic can run without
+  network access.
+- Add integration tests that exercise the full pipeline against recorded LiveRC
+  responses to catch schema drift.


### PR DESCRIPTION
## Summary
- document the LiveRC endpoint mappings and field normalisation rules for the Prisma/domain schema
- describe the ingestion workflow and session selection heuristics within core/app
- cross-link the new LiveRC contract from the main README and product guardrails

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dd108598bc8321865a1cc293b03047