### PR TITLE
feat: model LiveRC event hierarchy in Prisma

### DIFF
--- a/prisma/migrations/0002_liverc_entities/migration.sql
+++ b/prisma/migrations/0002_liverc_entities/migration.sql
@@ -1,0 +1,137 @@
+-- DropIndex
+DROP INDEX IF EXISTS "Lap_driverName_lapNumber_key";
+
+-- DropTable
+DROP TABLE IF EXISTS "Lap";
+
+-- CreateTable
+CREATE TABLE "Event" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sourceEventId" TEXT NOT NULL,
+    "sourceUrl" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Event_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RaceClass" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "classCode" TEXT NOT NULL,
+    "sourceUrl" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RaceClass_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "raceClassId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sourceSessionId" TEXT NOT NULL,
+    "sourceUrl" TEXT NOT NULL,
+    "scheduledStart" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Entrant" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "raceClassId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "carNumber" TEXT,
+    "sourceEntrantId" TEXT,
+    "sourceTransponderId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Entrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Lap" (
+    "id" TEXT NOT NULL,
+    "entrantId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "lapNumber" INTEGER NOT NULL,
+    "lapTimeMs" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Lap_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Event_sourceEventId_key" ON "Event"("sourceEventId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Event_sourceUrl_key" ON "Event"("sourceUrl");
+
+-- CreateIndex
+CREATE INDEX "Event_name_idx" ON "Event"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RaceClass_eventId_classCode_key" ON "RaceClass"("eventId", "classCode");
+
+-- CreateIndex
+CREATE INDEX "RaceClass_classCode_idx" ON "RaceClass"("classCode");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sourceSessionId_key" ON "Session"("sourceSessionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sourceUrl_key" ON "Session"("sourceUrl");
+
+-- CreateIndex
+CREATE INDEX "Session_eventId_idx" ON "Session"("eventId");
+
+-- CreateIndex
+CREATE INDEX "Session_raceClassId_idx" ON "Session"("raceClassId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Entrant_sessionId_displayName_key" ON "Entrant"("sessionId", "displayName");
+
+-- CreateIndex
+CREATE INDEX "Entrant_sourceEntrantId_idx" ON "Entrant"("sourceEntrantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Lap_entrantId_lapNumber_key" ON "Lap"("entrantId", "lapNumber");
+
+-- CreateIndex
+CREATE INDEX "Lap_sessionId_lapNumber_idx" ON "Lap"("sessionId", "lapNumber");
+
+-- AddForeignKey
+ALTER TABLE "RaceClass" ADD CONSTRAINT "RaceClass_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_raceClassId_fkey" FOREIGN KEY ("raceClassId") REFERENCES "RaceClass"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Entrant" ADD CONSTRAINT "Entrant_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Entrant" ADD CONSTRAINT "Entrant_raceClassId_fkey" FOREIGN KEY ("raceClassId") REFERENCES "RaceClass"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Entrant" ADD CONSTRAINT "Entrant_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Lap" ADD CONSTRAINT "Lap_entrantId_fkey" FOREIGN KEY ("entrantId") REFERENCES "Entrant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Lap" ADD CONSTRAINT "Lap_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "Session"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,13 +7,91 @@ generator client {
   provider = "prisma-client-js"
 }
 
+model Event {
+  id            String       @id @default(cuid())
+  name          String
+  sourceEventId String       @unique
+  sourceUrl     String       @unique
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+
+  raceClasses   RaceClass[]
+  sessions      Session[]
+  entrants      Entrant[]
+
+  @@index([name])
+}
+
+model RaceClass {
+  id        String    @id @default(cuid())
+  eventId   String
+  name      String
+  classCode String
+  sourceUrl String
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  event     Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  sessions  Session[]
+  entrants  Entrant[]
+
+  @@unique([eventId, classCode])
+  @@index([classCode])
+}
+
+model Session {
+  id              String    @id @default(cuid())
+  eventId         String
+  raceClassId     String
+  name            String
+  sourceSessionId String    @unique
+  sourceUrl       String    @unique
+  scheduledStart  DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  event     Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  raceClass RaceClass @relation(fields: [raceClassId], references: [id], onDelete: Cascade)
+  laps      Lap[]
+  entrants  Entrant[]
+
+  @@index([eventId])
+  @@index([raceClassId])
+}
+
+model Entrant {
+  id                  String    @id @default(cuid())
+  eventId             String
+  raceClassId         String
+  sessionId           String
+  displayName         String
+  carNumber           String?
+  sourceEntrantId     String?
+  sourceTransponderId String?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  event     Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  raceClass RaceClass @relation(fields: [raceClassId], references: [id], onDelete: Cascade)
+  session   Session   @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  laps      Lap[]
+
+  @@unique([sessionId, displayName])
+  @@index([sourceEntrantId])
+}
+
 model Lap {
   id         String   @id @default(cuid())
-  driverName String
+  entrantId  String
+  sessionId  String
   lapNumber  Int
   lapTimeMs  Int
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
-  @@unique([driverName, lapNumber])
+  entrant Entrant @relation(fields: [entrantId], references: [id], onDelete: Cascade)
+  session Session @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+
+  @@unique([entrantId, lapNumber])
+  @@index([sessionId, lapNumber])
 }

--- a/src/app/components/LapSummaryCard.tsx
+++ b/src/app/components/LapSummaryCard.tsx
@@ -6,7 +6,7 @@ export function LapSummaryCard({ summary }: { summary: LapSummary }) {
   return (
     <article className={styles.card}>
       <header className={styles.cardHeader}>
-        <h2 className={styles.cardTitle}>{summary.driverName}</h2>
+        <h2 className={styles.cardTitle}>{summary.entrantDisplayName}</h2>
         <p className={styles.cardSubtitle}>Lap overview</p>
       </header>
       <dl className={styles.statsGrid}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Script from 'next/script';
 
-import { lapSummaryService } from '@/dependencies/server';
+import { defaultEntrantContext, lapSummaryService } from '@/dependencies/server';
 import {
   absUrl,
   buildOrganizationJsonLd,
@@ -18,7 +18,7 @@ const PAGE_DESCRIPTION =
   'Baseline lap telemetry dashboards for racing teams, powered by a clean architecture Next.js foundation.';
 
 async function loadLapSummary() {
-  return lapSummaryService.getSummaryForDriver('Baseline Driver');
+  return lapSummaryService.getSummaryForEntrant(defaultEntrantContext.entrant.id);
 }
 
 export function generateMetadata(): Metadata {

--- a/src/core/app/index.ts
+++ b/src/core/app/index.ts
@@ -1,2 +1,5 @@
+export * from './ports/entrantRepository';
+export * from './ports/eventRepository';
 export * from './ports/lapRepository';
+export * from './ports/sessionRepository';
 export * from './services/getLapSummary';

--- a/src/core/app/ports/entrantRepository.ts
+++ b/src/core/app/ports/entrantRepository.ts
@@ -1,0 +1,7 @@
+import type { Entrant } from '@core/domain';
+
+export interface EntrantRepository {
+  getById(id: string): Promise<Entrant | null>;
+  findBySourceEntrantId(sourceEntrantId: string): Promise<Entrant | null>;
+  listBySession(sessionId: string): Promise<Entrant[]>;
+}

--- a/src/core/app/ports/eventRepository.ts
+++ b/src/core/app/ports/eventRepository.ts
@@ -1,0 +1,7 @@
+import type { Event } from '@core/domain';
+
+export interface EventRepository {
+  getById(id: string): Promise<Event | null>;
+  findBySourceId(sourceEventId: string): Promise<Event | null>;
+  findBySourceUrl(sourceUrl: string): Promise<Event | null>;
+}

--- a/src/core/app/ports/lapRepository.ts
+++ b/src/core/app/ports/lapRepository.ts
@@ -1,5 +1,5 @@
 import type { Lap } from '@core/domain';
 
 export interface LapRepository {
-  listByDriver(driverName: string): Promise<Lap[]>;
+  listByEntrant(entrantId: string): Promise<Lap[]>;
 }

--- a/src/core/app/ports/sessionRepository.ts
+++ b/src/core/app/ports/sessionRepository.ts
@@ -1,0 +1,9 @@
+import type { Session } from '@core/domain';
+
+export interface SessionRepository {
+  getById(id: string): Promise<Session | null>;
+  findBySourceId(sourceSessionId: string): Promise<Session | null>;
+  findBySourceUrl(sourceUrl: string): Promise<Session | null>;
+  listByEvent(eventId: string): Promise<Session[]>;
+  listByRaceClass(raceClassId: string): Promise<Session[]>;
+}

--- a/src/core/app/services/getLapSummary.ts
+++ b/src/core/app/services/getLapSummary.ts
@@ -1,12 +1,22 @@
 import { calculateLapSummary } from '@core/domain';
 
+import type { EntrantRepository } from '../ports/entrantRepository';
 import type { LapRepository } from '../ports/lapRepository';
 
 export class LapSummaryService {
-  constructor(private readonly lapRepository: LapRepository) {}
+  constructor(
+    private readonly lapRepository: LapRepository,
+    private readonly entrantRepository: EntrantRepository,
+  ) {}
 
-  async getSummaryForDriver(driverName: string) {
-    const laps = await this.lapRepository.listByDriver(driverName);
-    return calculateLapSummary(driverName, laps);
+  async getSummaryForEntrant(entrantId: string) {
+    const entrant = await this.entrantRepository.getById(entrantId);
+
+    if (!entrant) {
+      throw new Error(`Entrant not found for id ${entrantId}`);
+    }
+
+    const laps = await this.lapRepository.listByEntrant(entrantId);
+    return calculateLapSummary(entrant, laps);
   }
 }

--- a/src/core/domain/entrant.ts
+++ b/src/core/domain/entrant.ts
@@ -1,0 +1,16 @@
+export type EntrantSourceIdentifiers = {
+  entrantId?: string | null;
+  transponderId?: string | null;
+};
+
+export type Entrant = {
+  id: string;
+  eventId: string;
+  raceClassId: string;
+  sessionId: string;
+  displayName: string;
+  carNumber?: string | null;
+  source: EntrantSourceIdentifiers;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/core/domain/event.ts
+++ b/src/core/domain/event.ts
@@ -1,0 +1,12 @@
+export type EventSourceIdentifiers = {
+  eventId: string;
+  url: string;
+};
+
+export type Event = {
+  id: string;
+  name: string;
+  source: EventSourceIdentifiers;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/core/domain/index.ts
+++ b/src/core/domain/index.ts
@@ -1,1 +1,5 @@
+export * from './entrant';
+export * from './event';
 export * from './lap';
+export * from './raceClass';
+export * from './session';

--- a/src/core/domain/lap.ts
+++ b/src/core/domain/lap.ts
@@ -1,10 +1,13 @@
+import type { Entrant } from './entrant';
+
 export type LapTime = {
   milliseconds: number;
 };
 
 export type Lap = {
   id: string;
-  driverName: string;
+  entrantId: string;
+  sessionId: string;
   lapNumber: number;
   lapTime: LapTime;
   createdAt: Date;
@@ -12,16 +15,18 @@ export type Lap = {
 };
 
 export type LapSummary = {
-  driverName: string;
+  entrantId: string;
+  entrantDisplayName: string;
   lapsCompleted: number;
   bestLapMs: number;
   averageLapMs: number;
 };
 
-export const calculateLapSummary = (driverName: string, laps: Lap[]): LapSummary => {
+export const calculateLapSummary = (entrant: Entrant, laps: Lap[]): LapSummary => {
   if (laps.length === 0) {
     return {
-      driverName,
+      entrantId: entrant.id,
+      entrantDisplayName: entrant.displayName,
       lapsCompleted: 0,
       bestLapMs: 0,
       averageLapMs: 0,
@@ -32,7 +37,8 @@ export const calculateLapSummary = (driverName: string, laps: Lap[]): LapSummary
   const total = laps.reduce((acc, lap) => acc + lap.lapTime.milliseconds, 0);
 
   return {
-    driverName,
+    entrantId: entrant.id,
+    entrantDisplayName: entrant.displayName,
     lapsCompleted: laps.length,
     bestLapMs: sorted[0]?.lapTime.milliseconds ?? 0,
     averageLapMs: Math.round(total / laps.length),

--- a/src/core/domain/raceClass.ts
+++ b/src/core/domain/raceClass.ts
@@ -1,0 +1,9 @@
+export type RaceClass = {
+  id: string;
+  eventId: string;
+  name: string;
+  classCode: string;
+  sourceUrl: string;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/core/domain/session.ts
+++ b/src/core/domain/session.ts
@@ -1,0 +1,15 @@
+export type SessionSourceIdentifiers = {
+  sessionId: string;
+  url: string;
+};
+
+export type Session = {
+  id: string;
+  eventId: string;
+  raceClassId: string;
+  name: string;
+  source: SessionSourceIdentifiers;
+  scheduledStart?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/core/infra/index.ts
+++ b/src/core/infra/index.ts
@@ -1,2 +1,5 @@
 export * from './prisma/prismaClient';
+export * from './prisma/prismaEntrantRepository';
+export * from './prisma/prismaEventRepository';
 export * from './prisma/prismaLapRepository';
+export * from './prisma/prismaSessionRepository';

--- a/src/core/infra/prisma/prismaEntrantRepository.ts
+++ b/src/core/infra/prisma/prismaEntrantRepository.ts
@@ -1,0 +1,46 @@
+import type { EntrantRepository } from '@core/app';
+import type { Entrant } from '@core/domain';
+import type { Entrant as PrismaEntrant } from '@prisma/client';
+
+import { getPrismaClient } from './prismaClient';
+
+const toDomain = (entrant: PrismaEntrant): Entrant => ({
+  id: entrant.id,
+  eventId: entrant.eventId,
+  raceClassId: entrant.raceClassId,
+  sessionId: entrant.sessionId,
+  displayName: entrant.displayName,
+  carNumber: entrant.carNumber,
+  source: {
+    entrantId: entrant.sourceEntrantId,
+    transponderId: entrant.sourceTransponderId,
+  },
+  createdAt: entrant.createdAt,
+  updatedAt: entrant.updatedAt,
+});
+
+export class PrismaEntrantRepository implements EntrantRepository {
+  async getById(id: string): Promise<Entrant | null> {
+    const prisma = getPrismaClient();
+    const entrant = await prisma.entrant.findUnique({ where: { id } });
+
+    return entrant ? toDomain(entrant) : null;
+  }
+
+  async findBySourceEntrantId(sourceEntrantId: string): Promise<Entrant | null> {
+    const prisma = getPrismaClient();
+    const entrant = await prisma.entrant.findFirst({ where: { sourceEntrantId } });
+
+    return entrant ? toDomain(entrant) : null;
+  }
+
+  async listBySession(sessionId: string): Promise<Entrant[]> {
+    const prisma = getPrismaClient();
+    const entrants = await prisma.entrant.findMany({
+      where: { sessionId },
+      orderBy: { displayName: 'asc' },
+    });
+
+    return entrants.map(toDomain);
+  }
+}

--- a/src/core/infra/prisma/prismaEventRepository.ts
+++ b/src/core/infra/prisma/prismaEventRepository.ts
@@ -1,0 +1,39 @@
+import type { EventRepository } from '@core/app';
+import type { Event } from '@core/domain';
+import type { Event as PrismaEvent } from '@prisma/client';
+
+import { getPrismaClient } from './prismaClient';
+
+const toDomain = (event: PrismaEvent): Event => ({
+  id: event.id,
+  name: event.name,
+  source: {
+    eventId: event.sourceEventId,
+    url: event.sourceUrl,
+  },
+  createdAt: event.createdAt,
+  updatedAt: event.updatedAt,
+});
+
+export class PrismaEventRepository implements EventRepository {
+  async getById(id: string): Promise<Event | null> {
+    const prisma = getPrismaClient();
+    const event = await prisma.event.findUnique({ where: { id } });
+
+    return event ? toDomain(event) : null;
+  }
+
+  async findBySourceId(sourceEventId: string): Promise<Event | null> {
+    const prisma = getPrismaClient();
+    const event = await prisma.event.findUnique({ where: { sourceEventId } });
+
+    return event ? toDomain(event) : null;
+  }
+
+  async findBySourceUrl(sourceUrl: string): Promise<Event | null> {
+    const prisma = getPrismaClient();
+    const event = await prisma.event.findUnique({ where: { sourceUrl } });
+
+    return event ? toDomain(event) : null;
+  }
+}

--- a/src/core/infra/prisma/prismaLapRepository.ts
+++ b/src/core/infra/prisma/prismaLapRepository.ts
@@ -1,24 +1,28 @@
 import type { LapRepository } from '@core/app';
 import type { Lap } from '@core/domain';
+import type { Lap as PrismaLap } from '@prisma/client';
 
 import { getPrismaClient } from './prismaClient';
 
+const toDomain = (lap: PrismaLap): Lap => ({
+  id: lap.id,
+  entrantId: lap.entrantId,
+  sessionId: lap.sessionId,
+  lapNumber: lap.lapNumber,
+  lapTime: { milliseconds: lap.lapTimeMs },
+  createdAt: lap.createdAt,
+  updatedAt: lap.updatedAt,
+});
+
 export class PrismaLapRepository implements LapRepository {
-  async listByDriver(driverName: string): Promise<Lap[]> {
+  async listByEntrant(entrantId: string): Promise<Lap[]> {
     const prisma = getPrismaClient();
 
     const laps = await prisma.lap.findMany({
-      where: { driverName },
+      where: { entrantId },
       orderBy: { lapNumber: 'asc' },
     });
 
-    return laps.map((lap) => ({
-      id: lap.id,
-      driverName: lap.driverName,
-      lapNumber: lap.lapNumber,
-      lapTime: { milliseconds: lap.lapTimeMs },
-      createdAt: lap.createdAt,
-      updatedAt: lap.updatedAt,
-    }));
+    return laps.map(toDomain);
   }
 }

--- a/src/core/infra/prisma/prismaSessionRepository.ts
+++ b/src/core/infra/prisma/prismaSessionRepository.ts
@@ -1,0 +1,62 @@
+import type { SessionRepository } from '@core/app';
+import type { Session } from '@core/domain';
+import type { Session as PrismaSession } from '@prisma/client';
+
+import { getPrismaClient } from './prismaClient';
+
+const toDomain = (session: PrismaSession): Session => ({
+  id: session.id,
+  eventId: session.eventId,
+  raceClassId: session.raceClassId,
+  name: session.name,
+  source: {
+    sessionId: session.sourceSessionId,
+    url: session.sourceUrl,
+  },
+  scheduledStart: session.scheduledStart,
+  createdAt: session.createdAt,
+  updatedAt: session.updatedAt,
+});
+
+export class PrismaSessionRepository implements SessionRepository {
+  async getById(id: string): Promise<Session | null> {
+    const prisma = getPrismaClient();
+    const session = await prisma.session.findUnique({ where: { id } });
+
+    return session ? toDomain(session) : null;
+  }
+
+  async findBySourceId(sourceSessionId: string): Promise<Session | null> {
+    const prisma = getPrismaClient();
+    const session = await prisma.session.findUnique({ where: { sourceSessionId } });
+
+    return session ? toDomain(session) : null;
+  }
+
+  async findBySourceUrl(sourceUrl: string): Promise<Session | null> {
+    const prisma = getPrismaClient();
+    const session = await prisma.session.findUnique({ where: { sourceUrl } });
+
+    return session ? toDomain(session) : null;
+  }
+
+  async listByEvent(eventId: string): Promise<Session[]> {
+    const prisma = getPrismaClient();
+    const sessions = await prisma.session.findMany({
+      where: { eventId },
+      orderBy: { scheduledStart: 'asc' },
+    });
+
+    return sessions.map(toDomain);
+  }
+
+  async listByRaceClass(raceClassId: string): Promise<Session[]> {
+    const prisma = getPrismaClient();
+    const sessions = await prisma.session.findMany({
+      where: { raceClassId },
+      orderBy: { scheduledStart: 'asc' },
+    });
+
+    return sessions.map(toDomain);
+  }
+}


### PR DESCRIPTION
## Summary
- add Event, RaceClass, Session, and Entrant models plus a migration so laps reference entrant and session IDs
- introduce LiveRC-focused domain types and ports while updating the lap summary workflow to resolve entrants by ID
- implement Prisma repositories, seed data, and server fallbacks that populate and query the new event/session hierarchy

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dd10a7f5008321a1d0dd62844eadf4