### PR TITLE
chore: rename branding to My Race Engineer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ SMTP_PORT=587
 SMTP_SECURE=false
 SMTP_USER=mailer
 SMTP_PASS=change-me
-MAIL_FROM="Pace Tracer" <no-reply@example.com>
+MAIL_FROM="My Race Engineer" <no-reply@example.com>
 MAIL_REPLY_TO=help@example.com
 
 # Logging & telemetry
@@ -37,6 +37,6 @@ INGEST_RATE_LIMIT_WINDOW_MS=
 INGEST_RATE_LIMIT_MAX_REQUESTS=
 
 # Public
-NEXT_PUBLIC_APP_NAME=The Pace Tracer
+NEXT_PUBLIC_APP_NAME=My Race Engineer
 NEXT_PUBLIC_ENV=development
 NEXT_PUBLIC_BASE_URL=http://localhost:3001

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# The Pace Tracer — Agents Guide (Codex & other AI contributors)
+# My Race Engineer (MRE) — Agents Guide (Codex & other AI contributors)
 **Repo:** `JaysonBrenton/The-Pace-Tracer`  
 **Updated:** 2025-09-29  
 **Purpose:** Guardrails for automated/semi-automated contributions. Deep details will live in `docs/**`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Pace Tracer
+# My Race Engineer (MRE)
 **The one-stop lap logic shop.**  
 Next.js (App Router) + TypeScript + Prisma/PostgreSQL with clean layering, strict linting, structured error handling, and CI-friendly conventions.
 
@@ -25,7 +25,7 @@ Next.js (App Router) + TypeScript + Prisma/PostgreSQL with clean layering, stric
 ---
 
 ## What is this?
-The Pace Tracing Engineer (TPTE) is a lightweight pace and consistency analysis platform for **1/8 and 1/10 off-road RC racers**, their crews, and team managers. The MVP focuses on helping drivers turn race timing data into actionable setup and driving decisions through:
+My Race Engineer (MRE) is a lightweight pace and consistency analysis platform for **1/8 and 1/10 off-road RC racers**, their crews, and team managers. The MVP focuses on helping drivers turn race timing data into actionable setup and driving decisions through:
 
 - **Dashboard sign-in landing** that surfaces recent events, sessions, and key pace stats (best lap, median, standard deviation, outliers).
 - **LiveRC ingestion** (by event, session, or driver) with storage in a normalised format for quick comparison lookups.
@@ -266,7 +266,7 @@ Use **semantic colour tokens** instead of hard-coding hex in components.
 ---
 
 ## License
-The Pace Tracer is released under the [MIT License](LICENSE).
+My Race Engineer (MRE) is released under the [MIT License](LICENSE).
 
 You may use, copy, modify, merge, publish, distribute, sublicense, and sell
 copies of the software, provided that the copyright notice and permission

--- a/docs/guardrails/product-guardrails.md
+++ b/docs/guardrails/product-guardrails.md
@@ -1,6 +1,6 @@
-# TPTE MVP Product Guardrails
+# My Race Engineer (MRE) MVP Product Guardrails
 
-> Source: The Pace Tracing Engineer (TPTE) MVP brief.
+> Source: My Race Engineer (MRE) MVP brief.
 
 These guardrails translate the MVP narrative into actionable scope boundaries for all contributors. Treat them as non-functional requirements: every story and technical task should trace back to one or more of these guardrails.
 

--- a/docs/integrations/liverc-data-model.md
+++ b/docs/integrations/liverc-data-model.md
@@ -1,6 +1,6 @@
-# LiveRC → TPTE Data Contract
+# LiveRC → My Race Engineer (MRE) Data Contract
 
-This note captures the mapping between LiveRC timing endpoints and the Pace Tracer
+This note captures the mapping between LiveRC timing endpoints and the My Race Engineer (MRE)
 Prisma/domain schema. Use it as the contract for every ingestion change so that
 new adapters and tests stay aligned.
 

--- a/docs/roles/devops-platform-engineer.md
+++ b/docs/roles/devops-platform-engineer.md
@@ -1,7 +1,7 @@
 # DevOps & Platform Engineer
 
 ## Mission
-Provide resilient infrastructure, deployment automation, and runtime observability so The Pace Tracer ships predictably and recovers quickly across environments.
+Provide resilient infrastructure, deployment automation, and runtime observability so My Race Engineer (MRE) ships predictably and recovers quickly across environments.
 
 ## Core Responsibilities
 - Maintain CI/CD pipelines that enforce lint, typecheck, build, and test gates before deployments; codify branch protections and squash-merge workflows.

--- a/docs/roles/documentation-knowledge-steward.md
+++ b/docs/roles/documentation-knowledge-steward.md
@@ -1,7 +1,7 @@
 # Documentation & Knowledge Steward
 
 ## Mission
-Keep The Pace Tracer's institutional knowledge accurate, accessible, and actionable by curating documentation, decision records, and learning resources across the organisation.
+Keep My Race Engineer (MRE)'s institutional knowledge accurate, accessible, and actionable by curating documentation, decision records, and learning resources across the organisation.
 
 ## Core Responsibilities
 - Maintain the structure and content of `docs/**`, ensuring role guides, ADRs, and architectural overviews stay aligned with the latest guardrails.

--- a/docs/roles/nextjs-front-end-engineer.md
+++ b/docs/roles/nextjs-front-end-engineer.md
@@ -1,7 +1,7 @@
 # Next.js Front-End Engineer
 
 ## Mission
-Own the App Router user interface for The Pace Tracer, delivering resilient and accessible experiences while enforcing layered architecture contracts (UI → core/app), design token usage, and documented error boundaries.
+Own the App Router user interface for My Race Engineer (MRE), delivering resilient and accessible experiences while enforcing layered architecture contracts (UI → core/app), design token usage, and documented error boundaries.
 
 ## Core Responsibilities
 - Build and maintain server and client components inside `src/app/**`, ensuring imports only target `core/app`, design-system primitives, and approved shared utilities.

--- a/docs/roles/observability-incident-response-lead.md
+++ b/docs/roles/observability-incident-response-lead.md
@@ -1,7 +1,7 @@
 # Observability & Incident Response Lead
 
 ## Mission
-Ensure The Pace Tracer remains transparent and recoverable by defining telemetry standards, incident playbooks, and alerting thresholds that keep teams informed and responsive.
+Ensure My Race Engineer (MRE) remains transparent and recoverable by defining telemetry standards, incident playbooks, and alerting thresholds that keep teams informed and responsive.
 
 ## Core Responsibilities
 - Establish structured logging, metrics, and tracing conventions across UI, domain, and infrastructure components, emphasising correlation IDs and PII safeguards.

--- a/docs/roles/prisma-postgresql-backend-engineer.md
+++ b/docs/roles/prisma-postgresql-backend-engineer.md
@@ -1,7 +1,7 @@
 # Prisma/PostgreSQL Backend Engineer
 
 ## Mission
-Design and maintain the data persistence layer that powers The Pace Tracer, ensuring Prisma models and PostgreSQL migrations remain the authoritative, reproducible source of truth across environments.
+Design and maintain the data persistence layer that powers My Race Engineer (MRE), ensuring Prisma models and PostgreSQL migrations remain the authoritative, reproducible source of truth across environments.
 
 ## Core Responsibilities
 - Model database schemas within `prisma/schema.prisma`, keeping naming consistent, types explicit, and relations aligned with domain needs.

--- a/docs/roles/quality-automation-engineer.md
+++ b/docs/roles/quality-automation-engineer.md
@@ -1,7 +1,7 @@
 # Quality & Automation Engineer
 
 ## Mission
-Safeguard code quality by maintaining reliable automated checks, fast feedback loops, and pragmatic testing strategies that keep The Pace Tracer shippable at all times.
+Safeguard code quality by maintaining reliable automated checks, fast feedback loops, and pragmatic testing strategies that keep My Race Engineer (MRE) shippable at all times.
 
 ## Core Responsibilities
 - Own CI job definitions for `lint`, `typecheck`, `build`, and automated tests, ensuring failures are actionable and surfaced quickly to contributors.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "the-pace-tracer",
+  "name": "my-race-engineer",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,18 +10,18 @@ const appUrl = getAppUrl();
 export const metadata: Metadata = {
   metadataBase: appUrl,
   title: {
-    default: 'The Pace Tracer',
-    template: '%s | The Pace Tracer',
+    default: 'My Race Engineer (MRE)',
+    template: '%s | My Race Engineer (MRE)',
   },
   description: 'Telemetry insights for racing teams built on a clean, layered architecture.',
   openGraph: {
-    siteName: 'The Pace Tracer',
+    siteName: 'My Race Engineer (MRE)',
     url: appUrl.toString(),
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'The Pace Tracer',
+    title: 'My Race Engineer (MRE)',
     description: 'Telemetry insights for racing teams built on a clean, layered architecture.',
   },
 };

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -42,7 +42,7 @@ export default function OpengraphImage() {
               textTransform: 'uppercase',
             }}
           >
-            The Pace Tracer
+            My Race Engineer
           </span>
           <h1
             style={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ import {
 import { LapSummaryCard } from './components/LapSummaryCard';
 import styles from './page.module.css';
 
-const PAGE_TITLE = 'Pace Tracer telemetry insights';
+const PAGE_TITLE = 'My Race Engineer (MRE) telemetry insights';
 const PAGE_DESCRIPTION =
   'Baseline lap telemetry dashboards for racing teams, powered by a clean architecture Next.js foundation.';
 
@@ -41,7 +41,7 @@ export function generateMetadata(): Metadata {
           url: ogImageUrl,
           width: 1200,
           height: 630,
-          alt: 'Telemetry interface preview for The Pace Tracer.',
+          alt: 'Telemetry interface preview for My Race Engineer (MRE).',
         },
       ],
     },
@@ -60,11 +60,11 @@ export default async function Home() {
 
   const structuredData = [
     buildOrganizationJsonLd({
-      name: 'The Pace Tracer',
+      name: 'My Race Engineer (MRE)',
       url: canonical,
     }),
     buildWebsiteJsonLd({
-      name: 'The Pace Tracer',
+      name: 'My Race Engineer (MRE)',
       url: canonical,
     }),
     ...buildSiteNavigationJsonLd([
@@ -84,7 +84,7 @@ export default async function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
       <header className={styles.heroHeader}>
-        <h1 className={styles.heroTitle}>The Pace Tracer</h1>
+        <h1 className={styles.heroTitle}>My Race Engineer (MRE)</h1>
         <p className={styles.heroDescription}>{PAGE_DESCRIPTION}</p>
       </header>
       <div className={styles.cards}>

--- a/src/core/app/README.md
+++ b/src/core/app/README.md
@@ -2,7 +2,7 @@
 
 This package coordinates domain logic with infra adapters. The LiveRC ingestion
 service (to be implemented) will follow the pipeline below so all connectors stay
-consistent with the [`LiveRC → TPTE Data Contract`](../../../docs/integrations/liverc-data-model.md).
+consistent with the [`LiveRC → My Race Engineer (MRE) Data Contract`](../../../docs/integrations/liverc-data-model.md).
 
 ## Ingestion workflow
 


### PR DESCRIPTION
## Summary
- update application metadata, environment defaults, and social previews to reference My Race Engineer (MRE)
- refresh homepage copy and structured data so public-facing content reflects the new branding
- sweep guardrails and role documentation to replace legacy "The Pace Tracer"/"TPTE" references with the new name

## Testing
- npm run lint
- npm run typecheck *(fails: InMemoryEntrantRepository lacks upsertBySource required by EntrantRepository)*
- npm run build *(fails: Next.js cannot download Inter font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dddd10f65483219f49e096648204f3